### PR TITLE
checked transfers: skip 0 amounts & use OZ's safeERC20

### DIFF
--- a/src/utils/Erc20CheckedTransfer.sol
+++ b/src/utils/Erc20CheckedTransfer.sol
@@ -1,20 +1,44 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.18;
 
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {ERC20TransferFailed} from "../DataStructure/Errors.sol";
 
+/// @notice library to safely transfer ERC20 tokens, including not entirely compliant tokens like BNB and USDT
+/// @dev avoids bugs due to tokens not following the erc20 standard by not returning a boolean
+///     or by reverting on 0 amount transfers. Does not support fee on transfer tokens
 library Erc20CheckedTransfer {
-    function checkedTransferFrom(IERC20 currency, address from, address to, uint256 amount) internal {
-        if (!currency.transferFrom(from, to, amount)) {
-            revert ERC20TransferFailed(currency, from, to);
+    using SafeERC20 for IERC20;
+
+    /// @notice executes only if amount is greater than zero
+    /// @param amount amount to check
+    modifier skipZeroAmount(uint256 amount) {
+        if (amount > 0) {
+            _;
         }
     }
 
-    function checkedTransfer(IERC20 currency, address to, uint256 amount) internal {
-        if (!currency.transfer(to, amount)) {
-            revert ERC20TransferFailed(currency, address(this), to);
-        }
+    /// @notice safely transfers
+    /// @param currency ERC20 to transfer
+    /// @param from sender
+    /// @param to recipient
+    /// @param amount amount to transfer
+    function checkedTransferFrom(
+        IERC20 currency,
+        address from,
+        address to,
+        uint256 amount
+    ) internal skipZeroAmount(amount) {
+        currency.safeTransferFrom(from, to, amount);
+    }
+
+    /// @notice safely transfers
+    /// @param currency ERC20 to transfer
+    /// @param to recipient
+    /// @param amount amount to transfer
+    function checkedTransfer(IERC20 currency, address to, uint256 amount) internal skipZeroAmount(amount) {
+        currency.safeTransfer(to, amount);
     }
 }


### PR DESCRIPTION
fixes this [issue](https://github.com/sherlock-audit/2023-02-kairos-judging/issues/17)

`checkedTransferFrom` will now skip the external ERC20 call if the amount is 0

as a bonus, using OpenZeppelin's safeERC20 lib, we support tokens not returning a boolean on transfers