### PR TITLE
add a maxPrice param to buy args

### DIFF
--- a/src/DataStructure/Errors.sol
+++ b/src/DataStructure/Errors.sol
@@ -22,3 +22,4 @@ error InvalidTranche(uint256 nbOfTranches);
 error CollateralIsNotLiquidableYet(uint256 endDate, uint256 loanId);
 error UnsafeOfferLoanToValuesGap(uint256 minLoanToValue, uint256 maxLoanToValue);
 error UnsafeAmountLent(uint256 lent);
+error PriceOverMaximum(uint256 maxPrice, uint256 price);

--- a/src/DataStructure/Objects.sol
+++ b/src/DataStructure/Objects.sol
@@ -12,9 +12,11 @@ type Ray is uint256;
 /// @notice Arguments to buy the collateral of one loan
 /// @param loanId loan identifier
 /// @param to address that will receive the collateral
+/// @param maxPrice maximum price to pay for the collateral
 struct BuyArg {
     uint256 loanId;
     address to;
+    uint256 maxPrice;
 }
 
 /// @notice Arguments to borrow from one collateral

--- a/test/Auction/AuctionInternal.t.sol
+++ b/test/Auction/AuctionInternal.t.sol
@@ -22,8 +22,9 @@ contract TestAuction is Internal {
     }
 
     function testInitialPrice() public {
-        setTimeElapsed(0);
-        assertEq(price(testLoanId), lent.mul(protocolStorage().auction.priceFactor));
+        setTimeElapsed(1);
+        // 2999988425925925925 ~= lent.mul(protocolStorage().auction.priceFactor
+        assertEq(price(testLoanId), 2999988425925925925); // calculated price after 1 sec
     }
 
     function testPrice() public {

--- a/test/Commons/External.sol
+++ b/test/Commons/External.sol
@@ -29,7 +29,7 @@ contract External is SetUp, ERC721Holder {
     function storeAndGetArgs(Loan memory loan, uint256 loanId) internal returns (BuyArg[] memory) {
         BuyArg[] memory args = new BuyArg[](1);
         store(loan, loanId);
-        args[0] = BuyArg({loanId: loanId, to: signer});
+        args[0] = BuyArg({loanId: loanId, to: signer, maxPrice: 100 ether});
         return args;
     }
 


### PR DESCRIPTION
fixes https://github.com/sherlock-audit/2023-02-kairos-judging/issues/25

the buyer in auction can now precise a maxPrice it is willing to pay for an NFT preventing a reorg to make it pay more than expected

also in this PR
a duplicated checkLoanStatus is removed, loans are now liquidable strictly after loan.endDate