### PR TITLE
fix overflow in price (fix 76)

### DIFF
--- a/src/DataStructure/Errors.sol
+++ b/src/DataStructure/Errors.sol
@@ -24,3 +24,4 @@ error CollateralIsNotLiquidableYet(uint256 endDate, uint256 loanId);
 error UnsafeOfferLoanToValuesGap(uint256 minLoanToValue, uint256 maxLoanToValue);
 error UnsafeAmountLent(uint256 lent);
 error PriceOverMaximum(uint256 maxPrice, uint256 price);
+error ShareMatchedIsTooLow(Offer offer, uint256 requested);

--- a/test/Borrow/Borrow.t.sol
+++ b/test/Borrow/Borrow.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.18;
 
-import {BadCollateral, RequestedAmountIsUnderMinimum} from "../../src/DataStructure/Errors.sol";
+import {BadCollateral, RequestedAmountIsUnderMinimum, ShareMatchedIsTooLow} from "../../src/DataStructure/Errors.sol";
 import {BorrowArg, NFToken, Offer, OfferArg} from "../../src/DataStructure/Objects.sol";
 import {External} from "../Commons/External.sol";
 import {Loan, Provision} from "../../src/DataStructure/Storage.sol";
@@ -56,6 +56,24 @@ contract TestBorrow is External {
             )
         );
         kairos.borrow(borrowArgs);
+    }
+
+    function testShareMatchedTooLow() public {
+        vm.prank(OWNER);
+        kairos.setBorrowAmountPerOfferLowerBound(money, 1);
+        getJpeg(BORROWER, nft);
+        BorrowArg[] memory borrowArgs = getBorrowArgs();
+        borrowArgs[0].args[0].amount = 2;
+        vm.prank(BORROWER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ShareMatchedIsTooLow.selector,
+                borrowArgs[0].args[0].offer,
+                2
+            )
+        );
+        kairos.borrow(borrowArgs);
+
     }
 
     function testSimpleBorrow() public {

--- a/test/RayMath.t.sol
+++ b/test/RayMath.t.sol
@@ -9,6 +9,7 @@ import {stdError} from "forge-std/StdError.sol";
 
 contract TestRayMath is Test {
     using RayMath for Ray;
+    using RayMath for uint256;
 
     function testAdd() public {
         Ray a = Ray.wrap(100);
@@ -137,6 +138,18 @@ contract TestRayMath is Test {
         a = Ray.wrap(100);
         b = Ray.wrap(200);
         assertFalse(a.eq(b));
+    }
+
+    /// @notice this test shows that the worst case scenario values in the return value calculation of
+    ///     AuctionFacet.sol's price(uint256 loanId) method will not overflow
+    function testWorstCaseEstimatedValue() public pure {
+        // governance won't decide to set the initial price of liquidated NFTs to be over 100x their estimated value
+        Ray priceFactor = ONE.mul(100);
+        Ray decreasingFactor = ONE; // ONE is the max value of decreasingFactor
+        Ray shareLent = ONE.div(100_000_000); // we empirically chose this value as minimum shareLent
+        // 1e40 is the max value of loan.lent
+        uint256 estimatedValue = uint256(1e40).div(shareLent);
+        estimatedValue.mul(priceFactor).mul(decreasingFactor);
     }
 
     function assertEq(Ray a, Ray b) private {


### PR DESCRIPTION
fixes https://github.com/sherlock-audit/2023-02-kairos-judging/issues/76
to fix both possible overflow and division by 0 in price calculation, we calculated and hard set a safe minimum to the shareLent computed at borrow time